### PR TITLE
feat(register): Adiciona consentimento de Termos de Uso (LGPD)

### DIFF
--- a/CodigoFonte/src/components/TermsModal.jsx
+++ b/CodigoFonte/src/components/TermsModal.jsx
@@ -1,0 +1,52 @@
+// ARQUIVO: src/components/TermsModal.jsx
+
+import { X } from 'lucide-react';
+
+// Este componente recebe uma função 'onClose' para saber como se fechar.
+export default function TermsModal({ onClose }) {
+  return (
+    // Fundo escuro semi-transparente que cobre a tela inteira
+    <div className="fixed inset-0 bg-black bg-opacity-50 z-40 flex justify-center items-center">
+      {/* Contêiner do Modal */}
+      <div className="bg-white rounded-lg shadow-xl w-11/12 max-w-2xl p-6 relative">
+
+        {/* Botão de Fechar */}
+        <button
+          onClick={onClose}
+          className="absolute top-4 right-4 text-gray-500 hover:text-gray-800"
+        >
+          <X size={24} />
+        </button>
+
+        <h2 className="text-2xl font-bold mb-4">Termos de Uso</h2>
+        <div className="prose max-h-[60vh] overflow-y-auto pr-4">
+          <p>Bem-vindo ao MindTranslate!</p>
+          <p>Ao criar uma conta, você concorda com os seguintes termos:</p>
+
+          <h4>1. Coleta e Uso de Dados</h4>
+          <p>Coletamos seu nome e e-mail com o único propósito de criar e gerenciar sua conta, personalizar sua experiência e registrar seu progresso nos quizzes. Não compartilharemos seus dados com terceiros.</p>
+
+          <h4>2. Conduta do Usuário</h4>
+          <p>Você concorda em não usar a plataforma para qualquer atividade ilegal ou que prejudique o serviço ou outros usuários. O respeito mútuo é fundamental.</p>
+
+          <h4>3. Propriedade Intelectual</h4>
+          <p>Todo o conteúdo apresentado no MindTranslate, incluindo termos, quizzes e design, é de propriedade do projeto e não pode ser reproduzido sem permissão explícita.</p>
+
+          <h4>4. Limitação de Responsabilidade</h4>
+          <p>O MindTranslate é fornecido "como está". Embora nos esforcemos para a precisão do conteúdo, não garantimos que o serviço será ininterrupto ou livre de erros.</p>
+
+          <p>Obrigado por se juntar à nossa comunidade de aprendizado!</p>
+        </div>
+
+         <div className="text-right mt-6">
+             <button 
+                onClick={onClose}
+                className="px-6 py-2 bg-blue-600 text-white font-semibold rounded hover:bg-blue-700 transition"
+             >
+                Entendi
+            </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/CodigoFonte/src/pages/Register.jsx
+++ b/CodigoFonte/src/pages/Register.jsx
@@ -1,24 +1,33 @@
-import { useState } from 'react';
-import { useNavigate, Link } from 'react-router-dom';
-import { useAuth } from '../hooks/useAuth'; // Usa nosso hook centralizado
-import { Loader } from 'lucide-react';
-
+import { useState } from "react";
+import { useNavigate, Link } from "react-router-dom";
+import { useAuth } from "../hooks/useAuth"; // Usa nosso hook centralizado
+import { Loader } from "lucide-react";
+import TermsModal from "../components/TermsModal";
 export default function Register() {
   const navigate = useNavigate();
   const { register } = useAuth(); // Pega a função 'register' do contexto
 
-  const [name, setName] = useState('');
-  const [email, setEmail] = useState('');
-  const [password, setPassword] = useState('');
-  const [confirmPassword, setConfirmPassword] = useState(''); //adicionado
-  
+  const [name, setName] = useState("");
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState(""); //adicionado
+  // ========================================================================
+  // INÍCIO DA MANUTENÇÃO ADAPTATIVA (LGPD)
+  // ========================================================================
+
+  // 1. ADIÇÃO DE ESTADO: Novo estado para controlar o consentimento dos termos.
+  const [termsAccepted, setTermsAccepted] = useState(false);
+  const [isTermsModalOpen, setIsTermsModalOpen] = useState(false);
+
+  // ========================================================================
   const [error, setError] = useState(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   const handleRegister = async (event) => {
     event.preventDefault();
 
-    if (!name || !email || !password || !confirmPassword) { //adicionado
+    if (!name || !email || !password || !confirmPassword) {
+      //adicionado
       setError("Todos os campos são obrigatórios.");
       return;
     }
@@ -35,15 +44,14 @@ export default function Register() {
       // Chama a função unificada do nosso contexto.
       // O componente não sabe mais sobre Firebase, apenas sobre 'register'.
       await register(name, email, password);
-      
-      alert("Registro realizado com sucesso! Agora você pode fazer o login.");
-      navigate('/login');
 
+      alert("Registro realizado com sucesso! Agora você pode fazer o login.");
+      navigate("/login");
     } catch (err) {
       console.error("Erro no registro:", err);
-      if (err.code === 'auth/email-already-in-use') {
+      if (err.code === "auth/email-already-in-use") {
         setError("Este endereço de e-mail já está em uso.");
-      } else if (err.code === 'auth/weak-password') {
+      } else if (err.code === "auth/weak-password") {
         setError("A senha deve ter no mínimo 6 caracteres.");
       } else {
         setError("Ocorreu um erro inesperado. Tente novamente.");
@@ -55,84 +63,141 @@ export default function Register() {
   };
 
   return (
-    <main className="min-h-screen flex items-center justify-center bg-gray-100 px-4">
-      <div className="bg-white shadow-lg rounded-xl w-full max-w-md p-8 space-y-6">
-        <h2 className="text-3xl font-bold text-center text-gray-800">
-          Criar Conta
-        </h2>
+    <>
+      <main className="min-h-screen flex items-center justify-center bg-gray-100 px-4">
+        <div className="bg-white shadow-lg rounded-xl w-full max-w-md p-8 space-y-6">
+          <h2 className="text-3xl font-bold text-center text-gray-800">
+            Criar Conta
+          </h2>
 
-        <form onSubmit={handleRegister} className="space-y-4">
-          <div>
-            <label htmlFor="name" className="block text-sm font-medium text-gray-700">Nome completo</label>
-            <input
-              id="name"
-              type="text"
-              placeholder="João da Silva"
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-              required
-              className="mt-1 w-full px-4 py-2 border border-gray-300 rounded-md shadow-sm"
-            />
-          </div>
+          <form onSubmit={handleRegister} className="space-y-4">
+            <div>
+              <label
+                htmlFor="name"
+                className="block text-sm font-medium text-gray-700"
+              >
+                Nome completo
+              </label>
+              <input
+                id="name"
+                type="text"
+                placeholder="João da Silva"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                required
+                className="mt-1 w-full px-4 py-2 border border-gray-300 rounded-md shadow-sm"
+              />
+            </div>
 
-          <div>
-            <label htmlFor="email" className="block text-sm font-medium text-gray-700">E-mail</label>
-            <input
-              id="email"
-              type="email"
-              placeholder="voce@exemplo.com"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              required
-              className="mt-1 w-full px-4 py-2 border border-gray-300 rounded-md shadow-sm"
-            />
-          </div>
+            <div>
+              <label
+                htmlFor="email"
+                className="block text-sm font-medium text-gray-700"
+              >
+                E-mail
+              </label>
+              <input
+                id="email"
+                type="email"
+                placeholder="voce@exemplo.com"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                required
+                className="mt-1 w-full px-4 py-2 border border-gray-300 rounded-md shadow-sm"
+              />
+            </div>
 
-          <div>
-            <label htmlFor="password" className="block text-sm font-medium text-gray-700">Senha</label>
-            <input
-              id="password"
-              type="password"
-              placeholder="Mínimo 6 caracteres"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              required
-              className="mt-1 w-full px-4 py-2 border border-gray-300 rounded-md shadow-sm"
-            />
-          </div>
-        
+            <div>
+              <label
+                htmlFor="password"
+                className="block text-sm font-medium text-gray-700"
+              >
+                Senha
+              </label>
+              <input
+                id="password"
+                type="password"
+                placeholder="Mínimo 6 caracteres"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                required
+                className="mt-1 w-full px-4 py-2 border border-gray-300 rounded-md shadow-sm"
+              />
+            </div>
 
-          <div>
-            <label htmlFor="confirmPassword" className="block text-sm font-medium text-gray-700">Confirme a senha</label>
-            <input
-              id="confirmPassword"
-              type="password"
-              placeholder="Repita sua senha"
-              value={confirmPassword}
-              onChange={(e) => setConfirmPassword(e.target.value)}
-              required
-              className="mt-1 w-full px-4 py-2 border border-gray-300 rounded-md shadow-sm"
-            />
-          </div>
+            <div>
+              <label
+                htmlFor="confirmPassword"
+                className="block text-sm font-medium text-gray-700"
+              >
+                Confirme a senha
+              </label>
+              <input
+                id="confirmPassword"
+                type="password"
+                placeholder="Repita sua senha"
+                value={confirmPassword}
+                onChange={(e) => setConfirmPassword(e.target.value)}
+                required
+                className="mt-1 w-full px-4 py-2 border border-gray-300 rounded-md shadow-sm"
+              />
+            </div>
+            {/* ========================================================================
+              INÍCIO DA MANUTENÇÃO ADAPTATIVA (LGPD)
+              ======================================================================== */}
 
-          {error && <p className="text-sm text-red-600 text-center">{error}</p>}
+            {/* 2. ADIÇÃO DE UI: Bloco de JSX para o checkbox de consentimento. */}
+            <div className="flex items-center space-x-2 pt-2">
+              <input
+                id="terms"
+                type="checkbox"
+                checked={termsAccepted}
+                onChange={(e) => setTermsAccepted(e.target.checked)}
+                className="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+              />
+              <label htmlFor="terms" className="text-sm text-gray-600">
+                Eu li e concordo com os{" "}
+                <button
+                  type="button" // Essencial para não submeter o formulário
+                  onClick={() => setIsTermsModalOpen(true)}
+                  className="font-medium text-blue-600 hover:underline"
+                >
+                  Termos de Uso
+                </button>
+                .
+              </label>
+            </div>
 
-          <button
-            type="submit"
-            disabled={isSubmitting}
-            className="w-full flex justify-center items-center bg-blue-600 text-white py-2 px-4 rounded-md hover:bg-blue-700 transition disabled:bg-blue-300"
-          >
-            {isSubmitting ? <Loader className="animate-spin" /> : 'Cadastrar'}
-          </button>
-        </form>
+            {/* ======================================================================== */}
 
-        <p className="text-center text-sm text-gray-500">
-          Já tem uma conta?{" "}
-          <Link to="/login" className="font-medium text-blue-600 hover:underline">
-            Entrar
-          </Link>
-        </p>
-      </div>
-    </main>
+            {error && (
+              <p className="text-sm text-red-600 text-center">{error}</p>
+            )}
+
+            <button
+              type="submit"
+              disabled={isSubmitting}
+              className="w-full flex justify-center items-center bg-blue-600 text-white py-2 px-4 rounded-md hover:bg-blue-700 transition disabled:bg-blue-300"
+            >
+              {isSubmitting ? <Loader className="animate-spin" /> : "Cadastrar"}
+            </button>
+          </form>
+
+          <p className="text-center text-sm text-gray-500">
+            Já tem uma conta?{" "}
+            <Link
+              to="/login"
+              className="font-medium text-blue-600 hover:underline"
+            >
+              Entrar
+            </Link>
+          </p>
+        </div>
+      </main>
+      {/* ADICIONE ESTE BLOCO NO FINAL */}
+      {isTermsModalOpen && (
+        <TermsModal onClose={() => setIsTermsModalOpen(false)} />
+      )}
+    </>
   );
 }

--- a/CodigoFonte/src/pages/Register.jsx
+++ b/CodigoFonte/src/pages/Register.jsx
@@ -1,68 +1,59 @@
-import { useState } from "react";
-import { useNavigate, Link } from "react-router-dom";
-import { useAuth } from "../hooks/useAuth"; // Usa nosso hook centralizado
-import { Loader } from "lucide-react";
-import TermsModal from "../components/TermsModal";
+import { useState } from 'react';
+import { useNavigate, Link } from 'react-router-dom';
+import { useAuth } from '../hooks/useAuth';
+import { Loader } from 'lucide-react';
+import TermsModal from '../components/TermsModal'; // Importa o componente do Modal
+
 export default function Register() {
   const navigate = useNavigate();
-  const { register } = useAuth(); // Pega a função 'register' do contexto
+  const { register } = useAuth();
 
-  const [name, setName] = useState("");
-  const [email, setEmail] = useState("");
-  const [password, setPassword] = useState("");
-  const [confirmPassword, setConfirmPassword] = useState(""); //adicionado
-  // ========================================================================
-  // INÍCIO DA MANUTENÇÃO ADAPTATIVA (LGPD)
-  // ========================================================================
-
-  // 1. ADIÇÃO DE ESTADO: Novo estado para controlar o consentimento dos termos.
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
   const [termsAccepted, setTermsAccepted] = useState(false);
-  const [isTermsModalOpen, setIsTermsModalOpen] = useState(false);
-
+  
   // ========================================================================
+  // ALTERAÇÃO 1: Adição do estado para controlar a visibilidade do modal.
+  const [isTermsModalOpen, setIsTermsModalOpen] = useState(false);
+  // ========================================================================
+  
   const [error, setError] = useState(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   const handleRegister = async (event) => {
     event.preventDefault();
-
     if (!name || !email || !password || !confirmPassword) {
-      //adicionado
       setError("Todos os campos são obrigatórios.");
       return;
     }
-
     if (password !== confirmPassword) {
       setError("As senhas não coincidem.");
       return;
     }
-
     setIsSubmitting(true);
     setError(null);
-
     try {
-      // Chama a função unificada do nosso contexto.
-      // O componente não sabe mais sobre Firebase, apenas sobre 'register'.
       await register(name, email, password);
-
       alert("Registro realizado com sucesso! Agora você pode fazer o login.");
-      navigate("/login");
+      navigate('/login');
     } catch (err) {
       console.error("Erro no registro:", err);
-      if (err.code === "auth/email-already-in-use") {
+      if (err.code === 'auth/email-already-in-use') {
         setError("Este endereço de e-mail já está em uso.");
-      } else if (err.code === "auth/weak-password") {
+      } else if (err.code === 'auth/weak-password') {
         setError("A senha deve ter no mínimo 6 caracteres.");
       } else {
         setError("Ocorreu um erro inesperado. Tente novamente.");
       }
     } finally {
-      // Garante que o botão seja reativado mesmo se ocorrer um erro.
       setIsSubmitting(false);
     }
   };
 
   return (
+    // Usamos um Fragment (<>) para poder renderizar o modal como um "irmão" do <main>
     <>
       <main className="min-h-screen flex items-center justify-center bg-gray-100 px-4">
         <div className="bg-white shadow-lg rounded-xl w-full max-w-md p-8 space-y-6">
@@ -71,94 +62,24 @@ export default function Register() {
           </h2>
 
           <form onSubmit={handleRegister} className="space-y-4">
-            <div>
-              <label
-                htmlFor="name"
-                className="block text-sm font-medium text-gray-700"
-              >
-                Nome completo
-              </label>
-              <input
-                id="name"
-                type="text"
-                placeholder="João da Silva"
-                value={name}
-                onChange={(e) => setName(e.target.value)}
-                required
-                className="mt-1 w-full px-4 py-2 border border-gray-300 rounded-md shadow-sm"
-              />
-            </div>
+            {/* ...seus inputs de name, email, password, confirmPassword... */}
+            <div> <label htmlFor="name" className="block text-sm font-medium text-gray-700">Nome completo</label> <input id="name" type="text" placeholder="João da Silva" value={name} onChange={(e) => setName(e.target.value)} required className="mt-1 w-full px-4 py-2 border border-gray-300 rounded-md shadow-sm" /> </div> <div> <label htmlFor="email" className="block text-sm font-medium text-gray-700">E-mail</label> <input id="email" type="email" placeholder="voce@exemplo.com" value={email} onChange={(e) => setEmail(e.target.value)} required className="mt-1 w-full px-4 py-2 border border-gray-300 rounded-md shadow-sm" /> </div> <div> <label htmlFor="password" className="block text-sm font-medium text-gray-700">Senha</label> <input id="password" type="password" placeholder="Mínimo 6 caracteres" value={password} onChange={(e) => setPassword(e.target.value)} required className="mt-1 w-full px-4 py-2 border border-gray-300 rounded-md shadow-sm" /> </div> <div> <label htmlFor="confirmPassword" className="block text-sm font-medium text-gray-700">Confirme a senha</label> <input id="confirmPassword" type="password" placeholder="Repita sua senha" value={confirmPassword} onChange={(e) => setConfirmPassword(e.target.value)} required className="mt-1 w-full px-4 py-2 border border-gray-300 rounded-md shadow-sm" /> </div>
 
-            <div>
-              <label
-                htmlFor="email"
-                className="block text-sm font-medium text-gray-700"
-              >
-                E-mail
-              </label>
-              <input
-                id="email"
-                type="email"
-                placeholder="voce@exemplo.com"
-                value={email}
-                onChange={(e) => setEmail(e.target.value)}
-                required
-                className="mt-1 w-full px-4 py-2 border border-gray-300 rounded-md shadow-sm"
-              />
-            </div>
-
-            <div>
-              <label
-                htmlFor="password"
-                className="block text-sm font-medium text-gray-700"
-              >
-                Senha
-              </label>
-              <input
-                id="password"
-                type="password"
-                placeholder="Mínimo 6 caracteres"
-                value={password}
-                onChange={(e) => setPassword(e.target.value)}
-                required
-                className="mt-1 w-full px-4 py-2 border border-gray-300 rounded-md shadow-sm"
-              />
-            </div>
-
-            <div>
-              <label
-                htmlFor="confirmPassword"
-                className="block text-sm font-medium text-gray-700"
-              >
-                Confirme a senha
-              </label>
-              <input
-                id="confirmPassword"
-                type="password"
-                placeholder="Repita sua senha"
-                value={confirmPassword}
-                onChange={(e) => setConfirmPassword(e.target.value)}
-                required
-                className="mt-1 w-full px-4 py-2 border border-gray-300 rounded-md shadow-sm"
-              />
-            </div>
-            {/* ========================================================================
-              INÍCIO DA MANUTENÇÃO ADAPTATIVA (LGPD)
-              ======================================================================== */}
-
-            {/* 2. ADIÇÃO DE UI: Bloco de JSX para o checkbox de consentimento. */}
             <div className="flex items-center space-x-2 pt-2">
-              <input
-                id="terms"
-                type="checkbox"
+              <input 
+                id="terms" 
+                type="checkbox" 
                 checked={termsAccepted}
                 onChange={(e) => setTermsAccepted(e.target.checked)}
                 className="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
               />
+              {/* ========================================================================
+                  ALTERAÇÃO 2: O Link foi trocado por um botão que abre o modal.
+                  ======================================================================== */}
               <label htmlFor="terms" className="text-sm text-gray-600">
-                Eu li e concordo com os{" "}
+                Eu li e concordo com os{' '}
                 <button
-                  type="button" // Essencial para não submeter o formulário
+                  type="button"
                   onClick={() => setIsTermsModalOpen(true)}
                   className="font-medium text-blue-600 hover:underline"
                 >
@@ -167,37 +88,31 @@ export default function Register() {
                 .
               </label>
             </div>
-
-            {/* ======================================================================== */}
-
-            {error && (
-              <p className="text-sm text-red-600 text-center">{error}</p>
-            )}
+            
+            {error && <p className="text-sm text-red-600 text-center pt-2">{error}</p>}
 
             <button
               type="submit"
-              disabled={isSubmitting}
-              className="w-full flex justify-center items-center bg-blue-600 text-white py-2 px-4 rounded-md hover:bg-blue-700 transition disabled:bg-blue-300"
+              disabled={isSubmitting || !termsAccepted}
+              className="w-full flex justify-center items-center bg-blue-600 text-white py-2 px-4 rounded-md hover:bg-blue-700 transition disabled:bg-blue-300 disabled:cursor-not-allowed"
             >
-              {isSubmitting ? <Loader className="animate-spin" /> : "Cadastrar"}
+              {isSubmitting ? <Loader className="animate-spin" /> : 'Cadastrar'}
             </button>
           </form>
 
           <p className="text-center text-sm text-gray-500">
             Já tem uma conta?{" "}
-            <Link
-              to="/login"
-              className="font-medium text-blue-600 hover:underline"
-            >
+            <Link to="/login" className="font-medium text-blue-600 hover:underline">
               Entrar
             </Link>
           </p>
         </div>
       </main>
-      {/* ADICIONE ESTE BLOCO NO FINAL */}
-      {isTermsModalOpen && (
-        <TermsModal onClose={() => setIsTermsModalOpen(false)} />
-      )}
+
+      {/* ========================================================================
+          ALTERAÇÃO 3: O modal é renderizado aqui se o estado for 'true'.
+          ======================================================================== */}
+      {isTermsModalOpen && <TermsModal onClose={() => setIsTermsModalOpen(false)} />}
     </>
   );
 }


### PR DESCRIPTION

### 1. Descrição do Problema Adaptativo

Conforme planejado na **Estratégia 2** do nosso `plano-estrategia.md`, a página de registro não estava em conformidade com práticas de regulamentação de dados (como a LGPD), pois não solicitava o consentimento explícito do usuário aos Termos de Uso antes da criação da conta.

Esta manutenção adapta o sistema a este novo requisito regulatório.

**Resolve a Issue:** #1 

---

### 2. Adaptação Implementada

Para resolver o problema, as seguintes alterações foram feitas no componente `Register.jsx`:
- Adicionado um novo estado (`termsAccepted`) para controlar o checkbox de consentimento.
- Inserido um checkbox na UI, com um link em formato de modal para a leitura dos "Termos de Uso".
- A lógica do botão "Cadastrar" foi modificada para permanecer desabilitado (`disabled`) enquanto o checkbox de consentimento não estiver marcado.

---

### 3. Evidências de Funcionamento (Antes e Depois)

As imagens abaixo demonstram o comportamento do sistema antes e depois da adaptação, comprovando a eficácia da manutenção.

#### **Antes da Adaptação**

A tela de registro não possuía nenhum campo para o consentimento dos Termos de Uso. O usuário podia prosseguir com o cadastro sem confirmar a leitura e concordância.

![Imagem do WhatsApp de 2025-10-01 à(s) 05 30 38_8ce22b9e](https://github.com/user-attachments/assets/ee9610e8-eb88-45ef-a036-06271d0da395)

#### **Depois da Adaptação**

A nova interface agora inclui o checkbox de consentimento e a lógica de habilitação do botão, garantindo a conformidade.

**1. Botão Desabilitado (Estado Inicial):**
![Imagem do WhatsApp de 2025-10-01 à(s) 05 55 26_7e9aeef1](https://github.com/user-attachments/assets/c0103d66-1272-4167-8df9-741109dca97e)

**2. Botão Habilitado (Após Consentimento):**
![Imagem do WhatsApp de 2025-10-01 à(s) 05 55 47_22310866](https://github.com/user-attachments/assets/251ebc43-3507-4aeb-9c0f-38196fc851e3)

**3. Modal de Termos de Uso:**
O link para os "Termos de Uso" agora abre um modal, mantendo o usuário no fluxo de cadastro.
![Imagem do WhatsApp de 2025-10-01 à(s) 05 31 16_36f3303b](https://github.com/user-attachments/assets/d505fa97-d07a-45d3-b824-18ae3335c205)
